### PR TITLE
feat: doc tests in nightly can now be tested

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,9 @@ license = "MIT OR Apache-2.0"
 #[dependencies.compiler_builtins]
 #version = "0.1.87"
 
+[dev-dependencies]
+cfg-if = "1"
+
 [features]
 no_std = []
 const_trait_impl = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,17 +14,23 @@
 //! ```
 //!
 //!
-//! with `const_trait_impl` usage:
-//! ```compile_fail
+//! with `const_trait_impl` usage (requires `nightly`):
+//! ```
+//! # cfg_if::cfg_if! {
+//! # if #[cfg(nightly)] {
 //! # #![feature(const_trait_impl)]
 //! # use const_soft_float::soft_f32::SoftF32;
 //! const fn const_f32_add(a: f32, b: f32) -> f32 {
 //!     (SoftF32(a) + SoftF32(b)).to_f32()
 //! }
+//! # }
+//! # }
 //! ```
 //!
-//! with `const_mut_refs` usage:
-//! ```compile_fail
+//! with `const_mut_refs` usage (requires `nightly`):
+//! ```
+//! # cfg_if::cfg_if! {
+//! # if #[cfg(nightly)] {
 //! # #![feature(const_trait_impl)]
 //! # #![feature(const_mut_refs)]
 //! # use const_soft_float::soft_f32::SoftF32;
@@ -33,6 +39,8 @@
 //!     x += SoftF32(b);
 //!     x.to_f32()
 //! }
+//! # }
+//! # }
 //! ```
 //!
 //!


### PR DESCRIPTION
`cargo +nightly test` was failing on those tests until now.

This PR adds `cfg-if` in the doc tests to test if we are on Nightly and only then execute the doctest.

This is helpful because now we can include it in CI and run `nightly` to execute those tests.
