### PR TITLE
Add `exp` and `log` for `SoftFloat64`

### DIFF
--- a/fuzz/src/f64_fuzz.rs
+++ b/fuzz/src/f64_fuzz.rs
@@ -96,6 +96,42 @@ mod basic_tests {
     fn fuzz_trunc() {
         fuzz_test_op(SoftF64::trunc, f64::trunc, None, Some("trunc"));
     }
+
+    #[test]
+    fn fuzz_min() {
+        fuzz_test_op_2(
+            SoftF64::min,
+            f64::min,
+            crate::Argument::First,
+            None,
+            Some("min"),
+        );
+        fuzz_test_op_2(
+            SoftF64::min,
+            f64::min,
+            crate::Argument::Second,
+            None,
+            Some("min"),
+        );
+    }
+
+    #[test]
+    fn fuzz_max() {
+        fuzz_test_op_2(
+            SoftF64::max,
+            f64::max,
+            crate::Argument::First,
+            None,
+            Some("max"),
+        );
+        fuzz_test_op_2(
+            SoftF64::max,
+            f64::max,
+            crate::Argument::Second,
+            None,
+            Some("max"),
+        );
+    }
 }
 
 mod libm_tests {
@@ -139,5 +175,15 @@ mod libm_tests {
     fn fuzz_cos() {
         // cannot remove all instance of hard-float usage in libm, so
         fuzz_test_op(SoftF64::cos, libm::cos, Some(1e-6), Some("cos"))
+    }
+
+    #[test]
+    fn fuzz_ln() {
+        fuzz_test_op(SoftF64::ln, libm::log, None, Some("ln"));
+    }
+
+    #[test]
+    fn fuzz_exp() {
+        fuzz_test_op(SoftF64::exp, libm::exp, None, Some("exp"));
     }
 }

--- a/fuzz/src/lib.rs
+++ b/fuzz/src/lib.rs
@@ -331,7 +331,7 @@ mod sf64 {
 
     pub fn fuzz_test_op_2_other<T: nanorand::RandomGen<nanorand::WyRand, 8> + Display + Copy>(
         mut soft: impl FnMut(SoftF64, T) -> SoftF64,
-        mut hard: impl FnMut(f64, T) -> f64,
+        mut reference: impl FnMut(f64, T) -> f64,
         eps: Option<f64>,
         name: Option<&str>,
     ) {
@@ -348,7 +348,7 @@ mod sf64 {
 
         let mut hard = |x: f64| -> (f64, T) {
             let rand = hard_rng.generate::<T>();
-            let ret = hard(x, rand);
+            let ret = reference(x, rand);
             (ret, rand)
         };
 

--- a/src/soft_f64/exp.rs
+++ b/src/soft_f64/exp.rs
@@ -1,0 +1,159 @@
+// origin: SoftF64reeBSD /usr/src/lib/msun/src/e_exp.c
+// https://github.com/rust-lang/libm/blob/4c8a973741c014b11ce7f1477693a3e5d4ef9609/src/math/exp.rs
+//
+// ====================================================
+// Copyright (C) 2004 by Sun Microsystems, Inc. All rights reserved.
+//
+// Permission to use, copy, modify, and distribute this
+// software is freely granted, provided that this notice
+// is preserved.
+// ====================================================
+
+use super::{
+    helpers::{gt, lt, scalbn},
+    SoftF64,
+};
+
+// exp(x)
+// Returns the exponential of x.
+//
+// Method
+//   1. Argument reduction:
+//      Reduce x to an r so that |r| <= 0.5*ln2 ~ 0.34658.
+//      Given x, find r and integer k such that
+//
+//               x = k*ln2 + r,  |r| <= 0.5*ln2.
+//
+//      Here r will be represented as r = hi-lo for better
+//      accuracy.
+//
+//   2. Approximation of exp(r) by a special rational function on
+//      the interval [0,0.34658]:
+//      Write
+//          R(r**2) = r*(exp(r)+1)/(exp(r)-1) = 2 + r*r/6 - r**4/360 + ...
+//      We use a special Remez algorithm on [0,0.34658] to generate
+//      a polynomial of degree 5 to approximate R. The maximum error
+//      of this polynomial approximation is bounded by 2**-59. In
+//      other words,
+//          R(z) ~ 2.0 + P1*z + P2*z**2 + P3*z**3 + P4*z**4 + P5*z**5
+//      (where z=r*r, and the values of P1 to P5 are listed below)
+//      and
+//          |                  5          |     -59
+//          | 2.0+P1*z+...+P5*z   -  R(z) | <= 2
+//          |                             |
+//      The computation of exp(r) thus becomes
+//                              2*r
+//              exp(r) = 1 + ----------
+//                            R(r) - r
+//                                 r*c(r)
+//                     = 1 + r + ----------- (for better accuracy)
+//                                2 - c(r)
+//      where
+//                              2       4             10
+//              c(r) = r - (P1*r  + P2*r  + ... + P5*r   ).
+//
+//   3. Scale back to obtain exp(x):
+//      From step 1, we have
+//         exp(x) = 2^k * exp(r)
+//
+// Special cases:
+//      exp(INF) is INF, exp(NaN) is NaN;
+//      exp(-INF) is 0, and
+//      for finite argument, only exp(0)=1 is exact.
+//
+// Accuracy:
+//      according to an error analysis, the error is always less than
+//      1 ulp (unit in the last place).
+//
+// Misc. info.
+//      For IEEE double
+//          if x >  709.782712893383973096 then exp(x) overflows
+//          if x < -745.133219101941108420 then exp(x) underflows
+
+const HALF: [SoftF64; 2] = [SoftF64(0.5), SoftF64(-0.5)];
+const LN2HI: SoftF64 = SoftF64(6.93147180369123816490e-01); /* 0x3fe62e42, 0xfee00000 */
+const LN2LO: SoftF64 = SoftF64(1.90821492927058770002e-10); /* 0x3dea39ef, 0x35793c76 */
+const INVLN2: SoftF64 = SoftF64(1.44269504088896338700e+00); /* 0x3ff71547, 0x652b82fe */
+const P1: SoftF64 = SoftF64(1.66666666666666019037e-01); /* 0x3FC55555, 0x5555553E */
+const P2: SoftF64 = SoftF64(-2.77777777770155933842e-03); /* 0xBF66C16C, 0x16BEBD93 */
+const P3: SoftF64 = SoftF64(6.61375632143793436117e-05); /* 0x3F11566A, 0xAF25DE2C */
+const P4: SoftF64 = SoftF64(-1.65339022054652515390e-06); /* 0xBEBBBD41, 0xC5D26BF1 */
+const P5: SoftF64 = SoftF64(4.13813679705723846039e-08); /* 0x3E663769, 0x72BEA4D0 */
+
+/// Exponential, base *e* (f64)
+///
+/// Calculate the exponential of `x`, that is, *e* raised to the power `x`
+/// (where *e* is the base of the natural system of logarithms, approximately 2.71828).
+#[cfg_attr(all(test, assert_no_panic), no_panic::no_panic)]
+pub(crate) const fn exp(mut x: SoftF64) -> SoftF64 {
+    let x1p1023 = SoftF64::from_bits(0x7fe0000000000000); // 0x1p1023 === 2 ^ 1023
+                                                          // let x1p_149 = SoftF64::from_bits(0x36a0000000000000); // 0x1p-149 === 2 ^ -149
+
+    let hi: SoftF64;
+    let lo: SoftF64;
+    let c: SoftF64;
+    let xx: SoftF64;
+    let y: SoftF64;
+    let k: i32;
+    let sign: i32;
+    let mut hx: u32;
+
+    let abs_mask = SoftF64::SIGN_MASK - 1;
+
+    let x_bits = x.to_bits();
+
+    hx = (x_bits >> 32) as u32;
+    sign = (hx >> 31) as i32;
+    hx &= 0x7fffffff; /* high word of |x| */
+
+    /* special cases */
+    if hx >= 0x4086232b {
+        /* if |x| >= 708.39... */
+        if x_bits & abs_mask > SoftF64::EXPONENT_MASK {
+            return x;
+        }
+        if gt(x, SoftF64(709.782712893383973096)) {
+            /* overflow if x!=inf */
+            x = x.mul(x1p1023);
+            return x;
+        }
+        if lt(x, SoftF64(-708.39641853226410622)) {
+            /* underflow if x!=-inf */
+            if lt(x, SoftF64(-745.13321910194110842)) {
+                return SoftF64(0.);
+            }
+        }
+    }
+
+    /* argument reduction */
+    if hx > 0x3fd62e42 {
+        /* if |x| > 0.5 ln2 */
+        if hx >= 0x3ff0a2b2 {
+            /* if |x| >= 1.5 ln2 */
+            k = INVLN2.mul(x).add(HALF[sign as usize]).0 as i32;
+        } else {
+            k = 1 - sign - sign;
+        }
+        hi = x.sub(SoftF64(k as f64).mul(LN2HI)); /* k*ln2hi is exact here */
+        lo = SoftF64(k as f64).mul(LN2LO);
+        x = hi.sub(lo);
+    } else if hx > 0x3e300000 {
+        /* if |x| > 2**-28 */
+        k = 0;
+        hi = x;
+        lo = SoftF64(0.);
+    } else {
+        /* inexact if x!=0 */
+        return SoftF64(1.).add(x);
+    }
+
+    /* x is now in primary range */
+    xx = x.mul(x);
+    c = x.sub(xx.mul(P1.add(xx.mul(P2.add(xx.mul(P3.add(xx.mul(P4.add(xx.mul(P5))))))))));
+    y = SoftF64(1.).add(x.mul(c).div(SoftF64(2.).sub(c)).sub(lo).add(hi));
+    if k == 0 {
+        y
+    } else {
+        scalbn(y, k)
+    }
+}

--- a/src/soft_f64/helpers/cmp.rs
+++ b/src/soft_f64/helpers/cmp.rs
@@ -34,3 +34,14 @@ pub(crate) const fn ge(l: SoftF64, r: SoftF64) -> bool {
         panic!("Failed to compare values");
     }
 }
+
+pub(crate) const fn lt(l: SoftF64, r: SoftF64) -> bool {
+    if let Some(ord) = l.cmp(r) {
+        match ord {
+            Ordering::Less => true,
+            _ => false,
+        }
+    } else {
+        panic!("Failed to compare values");
+    }
+}

--- a/src/soft_f64/helpers/mod.rs
+++ b/src/soft_f64/helpers/mod.rs
@@ -5,7 +5,7 @@ mod rem_pio2;
 mod rem_pio2_large;
 mod scalbn;
 
-pub(crate) use cmp::{eq, ge, gt};
+pub(crate) use cmp::{eq, ge, gt, lt};
 pub(crate) use k_cos::k_cos;
 pub(crate) use k_sin::k_sin;
 pub(crate) use rem_pio2::rem_pio2;

--- a/src/soft_f64/log.rs
+++ b/src/soft_f64/log.rs
@@ -1,0 +1,122 @@
+// origin: FreeBSD /usr/src/lib/msun/src/e_log.c
+// https://github.com/rust-lang/libm/blob/4c8a973741c014b11ce7f1477693a3e5d4ef9609/src/math/log.rs
+//
+// ====================================================
+// Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+//
+// Developed at SunSoft, a Sun Microsystems, Inc. business.
+// Permission to use, copy, modify, and distribute this
+// software is freely granted, provided that this notice
+// is preserved.
+// ====================================================
+
+use super::SoftF64;
+
+// log(x)
+// Return the logarithm of x
+//
+// Method :
+//   1. Argument Reduction: find k and f such that
+//                      x = 2^k * (1+f),
+//         where  sqrt(2)/2 < 1+f < sqrt(2) .
+//
+//   2. Approximation of log(1+f).
+//      Let s = f/(2+f) ; based on log(1+f) = log(1+s) - log(1-s)
+//               = 2s + 2/3 s**3 + 2/5 s**5 + .....,
+//               = 2s + s*R
+//      We use a special Remez algorithm on [0,0.1716] to generate
+//      a polynomial of degree 14 to approximate R The maximum error
+//      of this polynomial approximation is bounded by 2**-58.45. In
+//      other words,
+//                      2      4      6      8      10      12      14
+//          R(z) ~ Lg1*s +Lg2*s +Lg3*s +Lg4*s +Lg5*s  +Lg6*s  +Lg7*s
+//      (the values of Lg1 to Lg7 are listed in the program)
+//      and
+//          |      2          14          |     -58.45
+//          | Lg1*s +...+Lg7*s    -  R(z) | <= 2
+//          |                             |
+//      Note that 2s = f - s*f = f - hfsq + s*hfsq, where hfsq = f*f/2.
+//      In order to guarantee error in log below 1ulp, we compute log
+//      by
+//              log(1+f) = f - s*(f - R)        (if f is not too large)
+//              log(1+f) = f - (hfsq - s*(hfsq+R)).     (better accuracy)
+//
+//      3. Finally,  log(x) = k*ln2 + log(1+f).
+//                          = k*ln2_hi+(f-(hfsq-(s*(hfsq+R)+k*ln2_lo)))
+//         Here ln2 is split into two floating point number:
+//                      ln2_hi + ln2_lo,
+//         where n*ln2_hi is always exact for |n| < 2000.
+//
+// Special cases:
+//      log(x) is NaN with signal if x < 0 (including -INF) ;
+//      log(+INF) is +INF; log(0) is -INF with signal;
+//      log(NaN) is that NaN with no signal.
+//
+// Accuracy:
+//      according to an error analysis, the error is always less than
+//      1 ulp (unit in the last place).
+//
+// Constants:
+// The hexadecimal values are the intended ones for the following
+// constants. The decimal values may be used, provided that the
+// compiler will convert from decimal to binary accurately enough
+// to produce the hexadecimal values shown.
+
+const LN2_HI: SoftF64 = SoftF64(6.93147180369123816490e-01); /* 3fe62e42 fee00000 */
+const LN2_LO: SoftF64 = SoftF64(1.90821492927058770002e-10); /* 3dea39ef 35793c76 */
+const LG1: SoftF64 = SoftF64(6.666666666666735130e-01); /* 3FE55555 55555593 */
+const LG2: SoftF64 = SoftF64(3.999999999940941908e-01); /* 3FD99999 9997FA04 */
+const LG3: SoftF64 = SoftF64(2.857142874366239149e-01); /* 3FD24924 94229359 */
+const LG4: SoftF64 = SoftF64(2.222219843214978396e-01); /* 3FCC71C5 1D8E78AF */
+const LG5: SoftF64 = SoftF64(1.818357216161805012e-01); /* 3FC74664 96CB03DE */
+const LG6: SoftF64 = SoftF64(1.531383769920937332e-01); /* 3FC39A09 D078C69F */
+const LG7: SoftF64 = SoftF64(1.479819860511658591e-01); /* 3FC2F112 DF3E5244 */
+
+pub(crate) const fn log(mut x: SoftF64) -> SoftF64 {
+    let x1p54 = SoftF64::from_bits(0x4350000000000000); // 0x1p54 === 2 ^ 54
+
+    let mut ui = x.to_bits();
+    let mut hx: u32 = (ui >> 32) as u32;
+    let mut k: i32 = 0;
+
+    if (hx < 0x00100000) || ((hx >> 31) != 0) {
+        /* x < 2**-126  */
+        if ui << 1 == 0 {
+            return SoftF64(-1.).div(x.mul(x)); /* log(+-0)=-inf */
+        }
+        if hx >> 31 != 0 {
+            return (x.sub(x)).div(SoftF64::ZERO); /* log(-#) = NaN */
+        }
+        /* subnormal number, scale x up */
+        k -= 54;
+        x = x.mul(x1p54);
+        ui = x.to_bits();
+        hx = (ui >> 32) as u32;
+    } else if hx >= 0x7ff00000 {
+        return x;
+    } else if hx == 0x3ff00000 && ui << 32 == 0 {
+        return SoftF64::ZERO;
+    }
+
+    /* reduce x into [sqrt(2)/2, sqrt(2)] */
+    hx += 0x3ff00000 - 0x3fe6a09e;
+    k += ((hx >> 20) as i32) - 0x3ff;
+    hx = (hx & 0x000fffff) + 0x3fe6a09e;
+    ui = ((hx as u64) << 32) | (ui & 0xffffffff);
+    x = SoftF64::from_bits(ui);
+
+    let f = x.sub(SoftF64::ONE);
+    let hfsq = SoftF64(0.5).mul(f).mul(f);
+    let s = f.div(SoftF64(2.0).add(f));
+    let z = s.mul(s);
+    let w = z.mul(z);
+    let t1 = w.mul(LG2.add(w.mul(LG4.add(w.mul(LG6)))));
+    let t2 = z.mul(LG1.add(w.mul(LG3.add(w.mul(LG5.add(w.mul(LG7)))))));
+    let r = t2.add(t1);
+    let dk = SoftF64(k as f64);
+    s.mul(hfsq.add(r))
+        .add(dk.mul(LN2_LO))
+        .sub(hfsq)
+        .add(f)
+        .add(dk.mul(LN2_HI))
+}

--- a/src/soft_f64/mod.rs
+++ b/src/soft_f64/mod.rs
@@ -5,7 +5,9 @@ pub mod cmp;
 pub mod copysign;
 pub mod cos;
 pub mod div;
+pub mod exp;
 pub mod floor;
+pub mod log;
 pub mod mul;
 pub mod pow;
 pub mod round;
@@ -98,6 +100,28 @@ impl SoftF64 {
     pub const fn cos(self) -> Self {
         cos::cos(self)
     }
+
+    pub const fn is_nan(self) -> bool {
+        !matches!(self.cmp(self), Some(core::cmp::Ordering::Equal))
+    }
+
+    pub const fn max(self, other: Self) -> Self {
+        let cond = self.is_nan() || matches!(self.cmp(other), Some(core::cmp::Ordering::Less));
+        (if cond { other } else { self }).mul(Self::ONE)
+    }
+
+    pub const fn min(self, other: Self) -> Self {
+        let cond = other.is_nan() || matches!(self.cmp(other), Some(core::cmp::Ordering::Less));
+        (if cond { self } else { other }).mul(Self::ONE)
+    }
+
+    pub const fn exp(self) -> Self {
+        exp::exp(self)
+    }
+
+    pub const fn ln(self) -> Self {
+        log::log(self)
+    }
 }
 
 type SelfInt = u64;
@@ -127,7 +151,7 @@ impl SoftF64 {
     const fn sign(self) -> bool {
         self.signed_repr() < 0
     }
-    const fn exp(self) -> SelfExpInt {
+    const fn exp2(self) -> SelfExpInt {
         ((self.to_bits() & Self::EXPONENT_MASK) >> Self::SIGNIFICAND_BITS) as SelfExpInt
     }
     const fn frac(self) -> SelfInt {


### PR DESCRIPTION
This is a draft for now since it's only implemented for `f64`, and doesn't have any tests.